### PR TITLE
Fix get_geno() + remove things that don't work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GNapi
-Version: 0.3-5
+Version: 0.3-6
 Date: 2022-09-26
 Title: Connection to the GeneNetwork API
 Description: Tools for connecting to the GeneNetwork API.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GNapi
-Version: 0.3-4
-Date: 2021-11-17
+Version: 0.3-5
+Date: 2022-09-26
 Title: Connection to the GeneNetwork API
 Description: Tools for connecting to the GeneNetwork API.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)
@@ -26,5 +26,5 @@ LazyData: true
 Encoding: UTF-8
 ByteCompile: true
 VignetteBuilder: knitr
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Roxygen: list(markdown=TRUE)

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -76,7 +76,7 @@ get_geno <-
 {
     stopifnot(length(group) == 1)
 
-    result <- query_gn(paste0("genotypes/", group), url=url, output="text")
+    result <- query_gn(paste0("genotypes/", group, ".geno"), url=url, output="text")
 
     # replace @ with #
     result <- gsub("@", "#", result, fixed=TRUE)

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -61,6 +61,7 @@ get_pheno <-
 #'
 #' @param group Name of group
 #' @param url The URL for the GeneNetwork API
+#' @param format The group's genotypes format
 #'
 #' @return A data frame
 #'
@@ -72,11 +73,11 @@ get_pheno <-
 #' @examples
 #' g <- get_geno("QSM")
 get_geno <-
-    function(group, url=gnapi_url())
+    function(group, url=gnapi_url(), format = "geno")
 {
     stopifnot(length(group) == 1)
 
-    result <- query_gn(paste0("genotypes/", group, ".geno"), url=url, output="text")
+    result <- query_gn(paste0("genotypes/", group, ".", format), url=url, output="text")
 
     # replace @ with #
     result <- gsub("@", "#", result, fixed=TRUE)

--- a/R/get_info.R
+++ b/R/get_info.R
@@ -4,7 +4,6 @@
 #'
 #' @param group Name of a group of datasets
 #' @param trait Trait identifier (can be a vector)
-#' @param limit Limit on number of traits to return (if `trait` is `NULL`)
 #' @param url The URL for the GeneNetwork API
 #'
 #' @return A data frame
@@ -13,20 +12,13 @@
 #'
 #' @examples
 #' info_pheno("BXD", "10002")
-#' info_pheno("HC_M2_0606_P", limit=10)
 #' info_pheno("HC_M2_0606_P", "1436869_at")
-#' info_pheno("HXBBXH", limit=10)
 info_pheno <-
-    function(group, trait=NULL, limit=NULL, url=gnapi_url())
+    function(group, trait, url=gnapi_url())
 {
     stopifnot(length(group)==1)
-    if(is.null(trait) || trait == "") {
-        query <- paste0("traits/", group)
-        if(!is.null(limit)) {
-            query <- paste0(query, "?limit_to=", limit)
-        }
-        result <- query_gn(query, url)
-        return(list2df(result))
+    if(is.null(trait) || (length(trait)==1 && trait == "")) {
+        stop("trait must be provided; can be a vector")
     }
 
     if(length(trait) > 1) {

--- a/R/get_lists.R
+++ b/R/get_lists.R
@@ -33,7 +33,6 @@ list_species <-
 #' Get list of available groups
 #'
 #' @param species Optional species name, for just the groups for that species.
-#' @param group Optional name for a specific group
 #' @param url URL for GeneNetwork API
 #'
 #' @return Data frame with columns `FullName`, `Id`, `Name`, and `TaxonomyId`.
@@ -45,21 +44,10 @@ list_species <-
 #' @examples
 #' list_groups()
 #' list_groups("barley")
-#' list_groups("rat", "HSNIH-Palmer")
-#' list_groups(group="HSNIH-Palmer")
 list_groups <-
-    function(species=NULL, group=NULL, url=gnapi_url())
+    function(species=NULL, url=gnapi_url())
 {
-    if(!is.null(group) && group != "") { # note this uses group/ rather than groups/
-        query <- "group/"
-        if(!is.null(species) && species != "") {
-            query <- paste0(query, "/", species)
-        }
-        result <- query_gn(paste0(query, "/", group), url=url)
-        if(is.null(result)) return(NULL)
-        return(as.data.frame(result))
-    }
-    else if(!is.null(species) && species != "") {
+    if(!is.null(species) && species != "") {
         stopifnot(length(species)==1)
         result <- query_gn(paste0("groups/", species), url=url)
     } else {

--- a/R/run_stuff.R
+++ b/R/run_stuff.R
@@ -14,7 +14,7 @@
 #' @export
 #'
 #' @examples
-#' out <- run_gemma("BXDPublish", "10015")
+#' \dontrun{out <- run_gemma("BXDPublish", "10015")}
 run_gemma <-
     function(dataset, trait, use_loco=FALSE, maf=0.01, url=gnapi_url())
 {

--- a/docs/GNapi.html
+++ b/docs/GNapi.html
@@ -120,13 +120,20 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
   for (var i = 0; i < sheets.length; i++) {
     if (sheets[i].ownerNode.dataset["origin"] !== "pandoc") continue;
     try { var rules = sheets[i].cssRules; } catch (e) { continue; }
-    for (var j = 0; j < rules.length; j++) {
+    var j = 0;
+    while (j < rules.length) {
       var rule = rules[j];
       // check if there is a div.sourceCode rule
-      if (rule.type !== rule.STYLE_RULE || rule.selectorText !== "div.sourceCode") continue;
+      if (rule.type !== rule.STYLE_RULE || rule.selectorText !== "div.sourceCode") {
+        j++;
+        continue;
+      }
       var style = rule.style.cssText;
       // check if color or background-color is set
-      if (rule.style.color === '' && rule.style.backgroundColor === '') continue;
+      if (rule.style.color === '' && rule.style.backgroundColor === '') {
+        j++;
+        continue;
+      }
       // replace div.sourceCode by a pre.sourceCode rule
       sheets[i].deleteRule(j);
       sheets[i].insertRule('pre.sourceCode{' + style + '}', j);
@@ -384,16 +391,14 @@ species:</p>
 </div>
 <div id="fetch-trait-information" class="section level2">
 <h2>Fetch trait information</h2>
-<p>This is mostly information about QTL location (LRS score and
-marker).</p>
-<p>You can get all traits within a microarray dataset, possibly limiting
-the results to some number.</p>
-<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="at">limit=</span><span class="dv">10</span>)</span></code></pre></div>
-<p>Or you can use a group name, again possibly limiting the results to
-some number.</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;HXBBXH&quot;</span>, <span class="at">limit=</span><span class="dv">10</span>)</span></code></pre></div>
-<p>Or you can get the information for a single trait.</p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;1436869_at&quot;</span>)</span></code></pre></div>
+<p>This is mostly information about QTL location (LRS score and marker).
+You need to provide a group and a trait, such as a probeset on a
+microarray:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;1436869_at&quot;</span>)</span></code></pre></div>
+<p>Or a traditional phenotype:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;BXD&quot;</span>, <span class="st">&quot;10002&quot;</span>)</span></code></pre></div>
+<p>You can provide a vector of trait identifiers:</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;BXD&quot;</span>, <span class="fu">c</span>(<span class="st">&quot;10002&quot;</span>, <span class="st">&quot;10010&quot;</span>, <span class="st">&quot;10100&quot;</span>))</span></code></pre></div>
 </div>
 <div id="fetch-sample-data-for-a-single-trait" class="section level2">
 <h2>Fetch sample data for a single trait</h2>

--- a/man/get_geno.Rd
+++ b/man/get_geno.Rd
@@ -4,12 +4,14 @@
 \alias{get_geno}
 \title{Get genotype data}
 \usage{
-get_geno(group, url = gnapi_url())
+get_geno(group, url = gnapi_url(), format = "geno")
 }
 \arguments{
 \item{group}{Name of group}
 
 \item{url}{The URL for the GeneNetwork API}
+
+\item{format}{The group's genotypes format}
 }
 \value{
 A data frame

--- a/man/info_pheno.Rd
+++ b/man/info_pheno.Rd
@@ -4,14 +4,12 @@
 \alias{info_pheno}
 \title{Get summary information about a phenotype}
 \usage{
-info_pheno(group, trait = NULL, limit = NULL, url = gnapi_url())
+info_pheno(group, trait, url = gnapi_url())
 }
 \arguments{
 \item{group}{Name of a group of datasets}
 
 \item{trait}{Trait identifier (can be a vector)}
-
-\item{limit}{Limit on number of traits to return (if \code{trait} is \code{NULL})}
 
 \item{url}{The URL for the GeneNetwork API}
 }
@@ -23,7 +21,5 @@ Get summary information about a phenotype
 }
 \examples{
 info_pheno("BXD", "10002")
-info_pheno("HC_M2_0606_P", limit=10)
 info_pheno("HC_M2_0606_P", "1436869_at")
-info_pheno("HXBBXH", limit=10)
 }

--- a/man/list_groups.Rd
+++ b/man/list_groups.Rd
@@ -4,12 +4,10 @@
 \alias{list_groups}
 \title{Get list of groups}
 \usage{
-list_groups(species = NULL, group = NULL, url = gnapi_url())
+list_groups(species = NULL, url = gnapi_url())
 }
 \arguments{
 \item{species}{Optional species name, for just the groups for that species.}
-
-\item{group}{Optional name for a specific group}
 
 \item{url}{URL for GeneNetwork API}
 }
@@ -22,8 +20,6 @@ Get list of available groups
 \examples{
 list_groups()
 list_groups("barley")
-list_groups("rat", "HSNIH-Palmer")
-list_groups(group="HSNIH-Palmer")
 }
 \seealso{
 \code{\link[=list_species]{list_species()}}, \code{\link[=list_datasets]{list_datasets()}}

--- a/man/run_gemma.Rd
+++ b/man/run_gemma.Rd
@@ -24,5 +24,5 @@ A data frame
 Perform a genome scan using gemma
 }
 \examples{
-out <- run_gemma("BXDPublish", "10015")
+\dontrun{out <- run_gemma("BXDPublish", "10015")}
 }

--- a/vignettes/GNapi.Rmd
+++ b/vignettes/GNapi.Rmd
@@ -105,25 +105,22 @@ list_datasets("bxd", "10001")
 ## Fetch trait information
 
 This is mostly information about QTL location (LRS score and marker).
-
-You can get all traits within a microarray dataset, possibly limiting the results
-to some number.
-
-```r
-info_pheno("HC_M2_0606_P", limit=10)
-```
-
-Or you can use a group name, again possibly limiting the results to
-some number.
-
-```r
-info_pheno("HXBBXH", limit=10)
-```
-
-Or you can get the information for a single trait.
+You need to provide a group and a trait, such as a probeset on a microarray:
 
 ```r
 info_pheno("HC_M2_0606_P", "1436869_at")
+```
+
+Or a traditional phenotype:
+
+```r
+info_pheno("BXD", "10002")
+```
+
+You can provide a vector of trait identifiers:
+
+```r
+info_pheno("BXD", c("10002", "10010", "10100"))
 ```
 
 


### PR DESCRIPTION
- GregFa fixed the  `get_geno()` problem
- `info_pheno()` doesn't work if you don't include a trait. In other words, you can't get a list of traits or probe sets like you used to be able to
- `list_groups()` no longer lets you give a particular group name
- `run_gemma()` doesn't seem to be working, currently; added `\dontrun{ }` in the example, for now