### PR TITLE
Fix URL for GN API + other small things

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
@@ -29,18 +29,21 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GNapi
-Version: 0.3-7
-Date: 2022-10-25
+Version: 0.3-8
+Date: 2023-07-26
 Title: Connection to the GeneNetwork API
 Description: Tools for connecting to the GeneNetwork API.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,5 +26,5 @@ LazyData: true
 Encoding: UTF-8
 ByteCompile: true
 VignetteBuilder: knitr
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Roxygen: list(markdown=TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 - Updated URL for GeneNetwork API
 
+- Remove an example from the vignette that no longer works:
+  "get the information for a specific group," `list_groups("rat", "HSNIH-Palmer")`
+
 
 ## GNapi 0.3-7 (2022-10-25)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## GNapi 0.3-8 (2023-07-26)
+
+### Minor changes
+
+- Updated URL for GeneNetwork API
+
+
 ## GNapi 0.3-7 (2022-10-25)
 
 ### Bug fixes

--- a/R/gnapi_url.R
+++ b/R/gnapi_url.R
@@ -10,5 +10,5 @@
 #' @export
 gnapi_url <- function()
 {
-    "http://gn2.genenetwork.org/api/v_pre1"
+    "https://genenetwork.org/api/v_pre1"
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## R/GNapi - R package to connect to the [GeneNetwork](https://genenetwork.org/) API
 
-[![R build status](https://github.com/rqtl/GNapi/workflows/R-CMD-check/badge.svg)](https://github.com/rqtl/GNapi/actions)
+[![R-CMD-check](https://github.com/rqtl/GNapi/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rqtl/GNapi/actions/workflows/R-CMD-check.yaml)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## R/GNapi - R package to connect to the [GeneNetwork](http://gn2.genenetwork.org/) API
+## R/GNapi - R package to connect to the [GeneNetwork](https://genenetwork.org/) API
 
 [![R build status](https://github.com/rqtl/GNapi/workflows/R-CMD-check/badge.svg)](https://github.com/rqtl/GNapi/actions)
 
@@ -24,7 +24,7 @@ Then use `remotes::install_github()` to install R/GNapi.
 ### Usage
 
 For an understanding of the
-[GeneNetwork](http://gn2.genenetwork.org) API, see
+[GeneNetwork](https://genenetwork.org) API, see
 [its
 documentation](https://github.com/genenetwork/genenetwork2/blob/testing/api_readme.md),
 as well as [Zachary Sloan](https://github.com/zsloan?tab=repositories)'s

--- a/docs/GNapi.html
+++ b/docs/GNapi.html
@@ -29,23 +29,23 @@ document.addEventListener('DOMContentLoaded', function(e) {
 </script>
 
 <style type="text/css">
-  code{white-space: pre-wrap;}
-  span.smallcaps{font-variant: small-caps;}
-  span.underline{text-decoration: underline;}
-  div.column{display: inline-block; vertical-align: top; width: 50%;}
-  div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-  ul.task-list{list-style: none;}
-    </style>
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+span.underline{text-decoration: underline;}
+div.column{display: inline-block; vertical-align: top; width: 50%;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+</style>
 
 
 
 <style type="text/css">
-  code {
-    white-space: pre;
-  }
-  .sourceCode {
-    overflow: visible;
-  }
+code {
+white-space: pre;
+}
+.sourceCode {
+overflow: visible;
+}
 </style>
 <style type="text/css" data-origin="pandoc">
 pre > code.sourceCode { white-space: pre; position: relative; }
@@ -63,55 +63,54 @@ pre > code.sourceCode { white-space: pre-wrap; }
 pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
-  { counter-reset: source-line 0; }
+{ counter-reset: source-line 0; }
 pre.numberSource code > span
-  { position: relative; left: -4em; counter-increment: source-line; }
+{ position: relative; left: -4em; counter-increment: source-line; }
 pre.numberSource code > span > a:first-child::before
-  { content: counter(source-line);
-    position: relative; left: -1em; text-align: right; vertical-align: baseline;
-    border: none; display: inline-block;
-    -webkit-touch-callout: none; -webkit-user-select: none;
-    -khtml-user-select: none; -moz-user-select: none;
-    -ms-user-select: none; user-select: none;
-    padding: 0 4px; width: 4em;
-    color: #aaaaaa;
-  }
-pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+{ content: counter(source-line);
+position: relative; left: -1em; text-align: right; vertical-align: baseline;
+border: none; display: inline-block;
+-webkit-touch-callout: none; -webkit-user-select: none;
+-khtml-user-select: none; -moz-user-select: none;
+-ms-user-select: none; user-select: none;
+padding: 0 4px; width: 4em;
+color: #aaaaaa;
+}
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa; padding-left: 4px; }
 div.sourceCode
-  {   }
+{ }
 @media screen {
 pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
 }
-code span.al { color: #ff0000; font-weight: bold; } /* Alert */
-code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
-code span.at { color: #7d9029; } /* Attribute */
-code span.bn { color: #40a070; } /* BaseN */
-code span.bu { } /* BuiltIn */
-code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
-code span.ch { color: #4070a0; } /* Char */
-code span.cn { color: #880000; } /* Constant */
-code span.co { color: #60a0b0; font-style: italic; } /* Comment */
-code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
-code span.do { color: #ba2121; font-style: italic; } /* Documentation */
-code span.dt { color: #902000; } /* DataType */
-code span.dv { color: #40a070; } /* DecVal */
-code span.er { color: #ff0000; font-weight: bold; } /* Error */
-code span.ex { } /* Extension */
-code span.fl { color: #40a070; } /* Float */
-code span.fu { color: #06287e; } /* Function */
-code span.im { } /* Import */
-code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
-code span.kw { color: #007020; font-weight: bold; } /* Keyword */
-code span.op { color: #666666; } /* Operator */
-code span.ot { color: #007020; } /* Other */
-code span.pp { color: #bc7a00; } /* Preprocessor */
-code span.sc { color: #4070a0; } /* SpecialChar */
-code span.ss { color: #bb6688; } /* SpecialString */
-code span.st { color: #4070a0; } /* String */
-code span.va { color: #19177c; } /* Variable */
-code span.vs { color: #4070a0; } /* VerbatimString */
-code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
-
+code span.al { color: #ff0000; font-weight: bold; } 
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.at { color: #7d9029; } 
+code span.bn { color: #40a070; } 
+code span.bu { color: #008000; } 
+code span.cf { color: #007020; font-weight: bold; } 
+code span.ch { color: #4070a0; } 
+code span.cn { color: #880000; } 
+code span.co { color: #60a0b0; font-style: italic; } 
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.do { color: #ba2121; font-style: italic; } 
+code span.dt { color: #902000; } 
+code span.dv { color: #40a070; } 
+code span.er { color: #ff0000; font-weight: bold; } 
+code span.ex { } 
+code span.fl { color: #40a070; } 
+code span.fu { color: #06287e; } 
+code span.im { color: #008000; font-weight: bold; } 
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.kw { color: #007020; font-weight: bold; } 
+code span.op { color: #666666; } 
+code span.ot { color: #007020; } 
+code span.pp { color: #bc7a00; } 
+code span.sc { color: #4070a0; } 
+code span.ss { color: #bb6688; } 
+code span.st { color: #4070a0; } 
+code span.va { color: #19177c; } 
+code span.vs { color: #4070a0; } 
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } 
 </style>
 <script>
 // apply pandoc div.sourceCode style to pre.sourceCode instead
@@ -342,8 +341,8 @@ code > span.er { color: #a61717; background-color: #e3d2d2; }
 
 
 <p>The <a href="https://github.com/rqtl/GNapi">R/GNapi</a> package
-provides access to the <a href="http://gn2.genenetwork.org">GeneNetwork2</a> API; for details on
-the API, see <a href="https://github.com/genenetwork/genenetwork2/blob/testing/api_readme.md">its
+provides access to the <a href="https://genenetwork.org">GeneNetwork2</a> API; for details on the
+API, see <a href="https://github.com/genenetwork/genenetwork2/blob/testing/api_readme.md">its
 documentation</a> The present vignette simply follows that documenation
 and shows the corresponding R facilities.</p>
 <div id="fetch-species-list" class="section level2">

--- a/docs/GNapi.html
+++ b/docs/GNapi.html
@@ -360,32 +360,30 @@ species:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_groups</span>()</span></code></pre></div>
 <p>You can also get the list of groups for a single species:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_groups</span>(<span class="st">&quot;rat&quot;</span>)</span></code></pre></div>
-<p>You can also get the information for a specific group:</p>
-<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_groups</span>(<span class="st">&quot;rat&quot;</span>, <span class="st">&quot;HSNIH-Palmer&quot;</span>)</span></code></pre></div>
 </div>
 <div id="fetch-genotypes-for-groupriset" class="section level2">
 <h2>Fetch genotypes for Group/RIset</h2>
-<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>g <span class="ot">&lt;-</span> <span class="fu">get_geno</span>(<span class="st">&quot;BXD&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a>g <span class="ot">&lt;-</span> <span class="fu">get_geno</span>(<span class="st">&quot;BXD&quot;</span>)</span></code></pre></div>
 </div>
 <div id="fetch-datasets" class="section level2">
 <h2>Fetch datasets</h2>
 <p>List datasets for a particular group.</p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="st">&quot;bxd&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="st">&quot;bxd&quot;</span>)</span></code></pre></div>
 <p>List a particular dataset.</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="st">&quot;bxd&quot;</span>, <span class="st">&quot;HC_M2_0606_P&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="st">&quot;bxd&quot;</span>, <span class="st">&quot;HC_M2_0606_P&quot;</span>)</span></code></pre></div>
 </div>
 <div id="fetch-sample-data-for-dataset" class="section level2">
 <h2>Fetch sample data for dataset</h2>
-<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>phe <span class="ot">&lt;-</span> <span class="fu">get_pheno</span>(<span class="st">&quot;HSNIH-PalmerPublish&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>phe <span class="ot">&lt;-</span> <span class="fu">get_pheno</span>(<span class="st">&quot;HSNIH-PalmerPublish&quot;</span>)</span></code></pre></div>
 <div id="information-for-mrna-assayprobeset" class="section level3">
 <h3>Information for mRNA assay/probeset</h3>
-<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="at">dataset=</span><span class="st">&quot;HC_M2_0606_P&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="at">dataset=</span><span class="st">&quot;HC_M2_0606_P&quot;</span>)</span></code></pre></div>
 <p>Or provide group/riset</p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="st">&quot;bxd&quot;</span>, <span class="st">&quot;HC_M2_0606_P&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="st">&quot;bxd&quot;</span>, <span class="st">&quot;HC_M2_0606_P&quot;</span>)</span></code></pre></div>
 </div>
 <div id="fetch-individual-phenotype-info" class="section level3">
 <h3>Fetch individual phenotype info</h3>
-<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="st">&quot;bxd&quot;</span>, <span class="st">&quot;10001&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">list_datasets</span>(<span class="st">&quot;bxd&quot;</span>, <span class="st">&quot;10001&quot;</span>)</span></code></pre></div>
 </div>
 </div>
 <div id="fetch-trait-information" class="section level2">
@@ -393,37 +391,37 @@ species:</p>
 <p>This is mostly information about QTL location (LRS score and marker).
 You need to provide a group and a trait, such as a probeset on a
 microarray:</p>
-<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;1436869_at&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;1436869_at&quot;</span>)</span></code></pre></div>
 <p>Or a traditional phenotype:</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;BXD&quot;</span>, <span class="st">&quot;10002&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;BXD&quot;</span>, <span class="st">&quot;10002&quot;</span>)</span></code></pre></div>
 <p>You can provide a vector of trait identifiers:</p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;BXD&quot;</span>, <span class="fu">c</span>(<span class="st">&quot;10002&quot;</span>, <span class="st">&quot;10010&quot;</span>, <span class="st">&quot;10100&quot;</span>))</span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;BXD&quot;</span>, <span class="fu">c</span>(<span class="st">&quot;10002&quot;</span>, <span class="st">&quot;10010&quot;</span>, <span class="st">&quot;10100&quot;</span>))</span></code></pre></div>
 </div>
 <div id="fetch-sample-data-for-a-single-trait" class="section level2">
 <h2>Fetch sample data for a single trait</h2>
-<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a>ph <span class="ot">&lt;-</span> <span class="fu">get_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;1436869_at&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>ph <span class="ot">&lt;-</span> <span class="fu">get_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;1436869_at&quot;</span>)</span></code></pre></div>
 <div id="for-mrna-expressionprobeset" class="section level3">
 <h3>For mRNA expression/probeset</h3>
-<div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;1436869_at&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;1436869_at&quot;</span>)</span></code></pre></div>
 </div>
 <div id="for-classical-phenotypes" class="section level3">
 <h3>For classical phenotypes</h3>
-<div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;BXD&quot;</span>, <span class="st">&quot;10001&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">info_pheno</span>(<span class="st">&quot;BXD&quot;</span>, <span class="st">&quot;10001&quot;</span>)</span></code></pre></div>
 </div>
 </div>
 <div id="analyses" class="section level2">
 <h2>Analyses</h2>
 <div id="gemma" class="section level3">
 <h3>Gemma</h3>
-<div class="sourceCode" id="cb19"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a>out <span class="ot">&lt;-</span> <span class="fu">run_gemma</span>(<span class="st">&quot;BXDPublish&quot;</span>, <span class="st">&quot;10015&quot;</span>, <span class="at">use_loco=</span><span class="cn">TRUE</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a>out <span class="ot">&lt;-</span> <span class="fu">run_gemma</span>(<span class="st">&quot;BXDPublish&quot;</span>, <span class="st">&quot;10015&quot;</span>, <span class="at">use_loco=</span><span class="cn">TRUE</span>)</span></code></pre></div>
 </div>
 <div id="rqtl" class="section level3">
 <h3>R/qtl</h3>
-<div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>out <span class="ot">&lt;-</span> <span class="fu">run_rqtl</span>(<span class="st">&quot;BXDPublish&quot;</span>, <span class="st">&quot;10015&quot;</span>, <span class="at">method=</span><span class="st">&quot;em&quot;</span>, <span class="at">interval_mapping=</span><span class="cn">TRUE</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a>out <span class="ot">&lt;-</span> <span class="fu">run_rqtl</span>(<span class="st">&quot;BXDPublish&quot;</span>, <span class="st">&quot;10015&quot;</span>, <span class="at">method=</span><span class="st">&quot;em&quot;</span>, <span class="at">interval_mapping=</span><span class="cn">TRUE</span>)</span></code></pre></div>
 </div>
 <div id="correlations" class="section level3">
 <h3>Correlations</h3>
-<div class="sourceCode" id="cb21"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>out <span class="ot">&lt;-</span> <span class="fu">run_correlation</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;BXDPublish&quot;</span>, <span class="st">&quot;1427571_at&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>out <span class="ot">&lt;-</span> <span class="fu">run_correlation</span>(<span class="st">&quot;HC_M2_0606_P&quot;</span>, <span class="st">&quot;BXDPublish&quot;</span>, <span class="st">&quot;1427571_at&quot;</span>)</span></code></pre></div>
 </div>
 </div>
 

--- a/vignettes/GNapi.Rmd
+++ b/vignettes/GNapi.Rmd
@@ -15,7 +15,7 @@ opts_chunk$set(fig.width=7, fig.height=4.5,
 ```
 
 The [R/GNapi](https://github.com/rqtl/GNapi) package provides
-access to the [GeneNetwork2](http://gn2.genenetwork.org) API; for
+access to the [GeneNetwork2](https://genenetwork.org) API; for
 details on the API, see [its
 documentation](https://github.com/genenetwork/genenetwork2/blob/testing/api_readme.md)
 The present vignette simply follows that documenation and shows the

--- a/vignettes/GNapi.Rmd
+++ b/vignettes/GNapi.Rmd
@@ -49,12 +49,6 @@ You can also get the list of groups for a single species:
 list_groups("rat")
 ```
 
-You can also get the information for a specific group:
-
-```r
-list_groups("rat", "HSNIH-Palmer")
-```
-
 ## Fetch genotypes for Group/RIset
 
 ```r


### PR DESCRIPTION
- Updated URL for GeneNetwork API

- Remove an example from the vignette that no longer works:
  "get the information for a specific group," `list_groups("rat", "HSNIH-Palmer")`
